### PR TITLE
chore: fix for right menu links on docs pages

### DIFF
--- a/content/en/about/index.md
+++ b/content/en/about/index.md
@@ -4,7 +4,7 @@ linkTitle: About
 menu: { main: { weight: 10 } }
 ---
 
-{{% blocks/cover promo_image="background.png"  title="Apache OpenServerless" %}}
+{{% blocks/cover promo_image="background.png"  title="Apache OpenServerless (incubating)" %}}
 
 {.mt-5}
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -136,7 +136,7 @@ params:
   url_latest_version: https://github.com/apache/openserverless/releases
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-  github_repo: https://github.com/apache/openserverless/issues
+  github_repo: https://github.com/apache/openserverless-site
 
   # An optional link to a related project repo. For example, the sibling repository where your product code lives.
   github_project_repo: https://github.com/apache/openserverless


### PR DESCRIPTION
 fix for right menu links on docs pages