### PR TITLE
update to a newer version of hugo-extended 0.144.2

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -58,7 +58,7 @@ tasks:
     silent: true
     desc: preview the websites
     cmds:
-      - PATH="node_modules/.bin:$PATH" hugo server --baseURL "http://localhost:1313/" --disableFastRender=false
+      - PATH="node_modules/.bin:$PATH" hugo server --baseURL "http://localhost:1313/" -O
 
   debug:
     silent: true

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "cross-env": "^7.0.3",
-    "hugo-extended": "0.133.0",
+    "hugo-extended": "0.144.2",
     "postcss": "^8.4.41",
     "postcss-cli": "^11.0.0"
   }


### PR DESCRIPTION
installing the site in local (to start explore the documentation repo) i found the latest task version (3.43.3) broke up with the -O argument inside - PATH="node_modules/.bin:$PATH" hugo server --baseURL "http://localhost:1313/" -O
raised thi PR if someone could evaluate the impact https://github.com/apache/openserverless-site/pull/66/files