### PR TITLE
[#67] fix dark-mode links for blog

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -37,6 +37,7 @@
     --td-pre-bg: #ececec;
     --bs-body-bg: #ffffff;
     --bs-emphasis-color: #333333;
+    --bs-body-color: #333333;
   }
   
   .dark-mode {


### PR DESCRIPTION
in dark mode the links to blog (articles, but also the already present news) are not very visible
<img width="1165" height="774" alt="image" src="https://github.com/user-attachments/assets/4943fb91-7da7-409f-a439-64a32208ef17" />

result with the applied fix:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/1c22acf2-8a7a-44a1-967b-127c05aa7b97" />
